### PR TITLE
Add logic to detect IAM roles and use S3

### DIFF
--- a/bakthat/backends.py
+++ b/bakthat/backends.py
@@ -128,7 +128,17 @@ class GlacierBackend(BakthatBackend):
     def __init__(self, conf={}, profile="default"):
         BakthatBackend.__init__(self, conf, profile)
 
-        con = boto.connect_glacier(aws_access_key_id=self.conf["access_key"], aws_secret_access_key=self.conf["secret_key"], region_name=self.conf["region_name"])
+        # Allow for AWS environments with roles to use bakthat
+        if self.conf["access_key"] == "" and self.conf["secret_key"] == "":
+            con = boto.connect_glacier(
+                region_name=self.conf["region_name"]
+            )
+        else:
+            con = boto.connect_glacier(
+                aws_access_key_id=self.conf["access_key"],
+                aws_secret_access_key=self.conf["secret_key"],
+                region_name=self.conf["region_name"]
+            )
 
         self.vault = con.create_vault(self.conf["glacier_vault"])
         self.backup_key = "bakthat_glacier_inventory"

--- a/bakthat/backends.py
+++ b/bakthat/backends.py
@@ -72,7 +72,7 @@ class S3Backend(BakthatBackend):
         # Allow for AWS environments with roles to use bakthat
         if self.conf["access_key"] == "" and self.conf["secret_key"] == "":
             con = boto.connect_s3()
-        else
+        else:
             con = boto.connect_s3(self.conf["access_key"], self.conf["secret_key"])
 
         region_name = self.conf["region_name"]

--- a/bakthat/backends.py
+++ b/bakthat/backends.py
@@ -69,7 +69,11 @@ class S3Backend(BakthatBackend):
     def __init__(self, conf={}, profile="default"):
         BakthatBackend.__init__(self, conf, profile)
 
-        con = boto.connect_s3(self.conf["access_key"], self.conf["secret_key"])
+        # Allow for AWS environments with roles to use bakthat
+        if self.conf["access_key"] == "" and self.conf["secret_key"] == "":
+            con = boto.connect_s3()
+        else
+            con = boto.connect_s3(self.conf["access_key"], self.conf["secret_key"])
 
         region_name = self.conf["region_name"]
         if region_name == DEFAULT_LOCATION:

--- a/bakthat/backends.py
+++ b/bakthat/backends.py
@@ -141,6 +141,7 @@ class GlacierBackend(BakthatBackend):
             )
 
         self.vault = con.create_vault(self.conf["glacier_vault"])
+        self.vault.name = str(self.vault.name)  #  https://github.com/boto/boto/issues/3318
         self.backup_key = "bakthat_glacier_inventory"
         self.container = self.conf["glacier_vault"]
         self.container_key = "glacier_vault"


### PR DESCRIPTION
`boto.connect_s3` works with no arguments on EC2 instances with roles that allow access to S3.
